### PR TITLE
feat: Allow custom inject token for async registration with  property

### DIFF
--- a/lib/clickhouse.module.ts
+++ b/lib/clickhouse.module.ts
@@ -23,6 +23,7 @@ export interface ClickHouseModuleAsyncOptions
   ) => Promise<ClickHouseModuleOptions> | ClickHouseModuleOptions;
   inject?: any[];
   extraProviders?: Provider[];
+  name?: string;
 }
 
 @Module({})
@@ -52,7 +53,7 @@ export class ClickHouseModule {
     const providers = [
       ...this.createAsyncProviders(options),
       {
-        provide: CLICKHOUSE_ASYNC_INSTANCE_TOKEN,
+        provide: options.name || CLICKHOUSE_ASYNC_INSTANCE_TOKEN,
         useFactory: (options: ClickHouseModuleOptions) => {
           if (!options) {
             options = new ClickHouseModuleOptions();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Cannot set a custom async token to inject multiple registerAsync clickhouse clients.

## What is the new behavior?

Now, we can.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
